### PR TITLE
Simplify sign‑in to username and email

### DIFF
--- a/client/app/api/auth/login/route.ts
+++ b/client/app/api/auth/login/route.ts
@@ -4,16 +4,16 @@ import { signIn } from '@/lib/auth';
 import { DEFAULT_LOGIN_REDIRECT } from '@/routes';
 
 export const POST = async (req: Request) => {
-  const { email, password } = await req.json();
+  const { email, name } = await req.json();
 
-  if (!email || !password) {
+  if (!email || !name) {
     return new NextResponse('Missing Fields', { status: 400 });
   }
 
   try {
     await signIn('credentials', {
       email,
-      password,
+      name,
     });
 
     return new Response('Redirect', {

--- a/client/app/api/auth/register/route.ts
+++ b/client/app/api/auth/register/route.ts
@@ -1,13 +1,11 @@
-import bcrypt from 'bcryptjs';
-
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { getUserByEmail } from '@/actions/get-user';
 
 export const POST = async (req: Request) => {
-  const { name, email, password } = await req.json();
+  const { name, email } = await req.json();
 
-  if (!name || !email || !password) {
+  if (!name || !email) {
     return new NextResponse('Missing Fields', { status: 400 });
   }
 
@@ -17,13 +15,10 @@ export const POST = async (req: Request) => {
     return new NextResponse('Email exists', { status: 400 });
   }
 
-  const hashedPassword = await bcrypt.hash(password, 10);
-
   const user = await db.user.create({
     data: {
       name,
       email,
-      password: hashedPassword,
     },
   });
 

--- a/client/app/auth/register-user.ts
+++ b/client/app/auth/register-user.ts
@@ -1,7 +1,5 @@
 'use server';
 
-import bcrypt from 'bcryptjs';
-
 import { redirect } from 'next/navigation';
 import { db } from '@/lib/db';
 import { getUserByEmail } from '@/actions/get-user';
@@ -9,13 +7,10 @@ import { getUserByEmail } from '@/actions/get-user';
 interface UserDetails {
   name: string;
   email: string;
-  password: string;
 }
 
-export const registerUser = async ({ name, email, password }: UserDetails) => {
-  const hashedPassword = await bcrypt.hash(password, 10);
-
-  if (!name || !email || !password) {
+export const registerUser = async ({ name, email }: UserDetails) => {
+  if (!name || !email) {
     throw new Error('Missing fields.');
   }
 
@@ -29,7 +24,6 @@ export const registerUser = async ({ name, email, password }: UserDetails) => {
     data: {
       name,
       email,
-      password: hashedPassword,
     },
   });
 

--- a/client/lib/validations/auth-schema.ts
+++ b/client/lib/validations/auth-schema.ts
@@ -2,33 +2,14 @@ import * as z from 'zod';
 
 export const loginFormSchema = z.object({
   email: z.string().email('Invalid email'),
-  password: z
+  name: z
     .string()
-    .min(6, 'Password should be at least 6 characters long')
-    .max(20, 'Password is too long (maximum 20 characters)'),
+    .min(2, 'Name should be at least 2 characters long')
+    .max(15, 'Name is too long (maximum 15 characters)'),
 });
 
 export type LoginFormValues = z.infer<typeof loginFormSchema>;
 
-export const registerFormSchema = z
-  .object({
-    email: z.string().email('Invalid email'),
-    name: z
-      .string()
-      .min(2, 'Name should be at least 2 characters long')
-      .max(15, 'Name is too long (maximum 15 characters)'),
-    password: z
-      .string()
-      .min(6, 'Password should be at least 6 characters long')
-      .max(20, 'Password is too long (maximum 20 characters)'),
-    confirmPassword: z
-      .string()
-      .min(6, 'Confirm Password should be at least 6 characters long')
-      .max(20, 'Confirm Password is too long (maximum 20 characters)'),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    path: ['confirmPassword'],
-    message: 'Passwords do not match',
-  });
+export const registerFormSchema = loginFormSchema;
 
 export type RegisterFormValues = z.infer<typeof registerFormSchema>;


### PR DESCRIPTION
## Summary
- remove password fields from client validation
- adjust auth form to only ask for name and email
- simplify NextAuth credentials provider to auto-create users
- update login and register API routes for the new schema
- drop password handling from register user utility

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843e86fad30832cbb935092e6902079